### PR TITLE
Activate short test

### DIFF
--- a/Makefile.prow
+++ b/Makefile.prow
@@ -10,8 +10,7 @@ push-prow: build-prow
 build-prow: 
 	docker build -f Dockerfile . -t ${REPO_URL}/cluster-backup-operator:${VERSION}
 
-#.PHONY: unit-tests
-#unit-tests:
-#	GOFLAGS="" go test -timeout 120s -v -short ./controllers/clusterclaims
-#	GOFLAGS="" go test -timeout 120s -v -short ./controllers/clusterpools
+.PHONY: unit-tests
+unit-tests:
+	GOFLAGS="" go test -timeout 120s -v -short ./controllers
 	


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

* Disables the generator call in `make test` so that prow can call `make unit-tests`
* Activates a `make unit-tests`