### PR TITLE
move GH domain to open-cluster-management/

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -22,8 +22,8 @@ import (
 	"sort"
 	"time"
 
-	v1beta1 "github.com/open-cluster-management-io/cluster-backup-operator/api/v1beta1"
 	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
+	v1beta1 "github.com/open-cluster-management/cluster-backup-operator/api/v1beta1"
 	chnv1 "github.com/open-cluster-management/multicloud-operators-channel/pkg/apis/apps/v1"
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	v1beta1 "github.com/open-cluster-management-io/cluster-backup-operator/api/v1beta1"
+	v1beta1 "github.com/open-cluster-management/cluster-backup-operator/api/v1beta1"
 	"github.com/pkg/errors"
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/backup_controller_test.go
+++ b/controllers/backup_controller_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1beta1 "github.com/open-cluster-management-io/cluster-backup-operator/api/v1beta1"
 	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
+	v1beta1 "github.com/open-cluster-management/cluster-backup-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/controllers/backup_test.go
+++ b/controllers/backup_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	v1beta1 "github.com/open-cluster-management-io/cluster-backup-operator/api/v1beta1"
+	v1beta1 "github.com/open-cluster-management/cluster-backup-operator/api/v1beta1"
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controllers
 
 import (
-	v1beta1 "github.com/open-cluster-management-io/cluster-backup-operator/api/v1beta1"
+	v1beta1 "github.com/open-cluster-management/cluster-backup-operator/api/v1beta1"
 )
 
 // IsRestoreFinsihed returns true when Restore is finished

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	v1beta1 "github.com/open-cluster-management-io/cluster-backup-operator/api/v1beta1"
+	v1beta1 "github.com/open-cluster-management/cluster-backup-operator/api/v1beta1"
 )
 
 var (

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -6,7 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	v1beta1 "github.com/open-cluster-management-io/cluster-backup-operator/api/v1beta1"
+	v1beta1 "github.com/open-cluster-management/cluster-backup-operator/api/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -3,7 +3,7 @@ package controllers
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	v1beta1 "github.com/open-cluster-management-io/cluster-backup-operator/api/v1beta1"
+	v1beta1 "github.com/open-cluster-management/cluster-backup-operator/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -30,8 +30,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	backupv1beta1 "github.com/open-cluster-management-io/cluster-backup-operator/api/v1beta1"
 	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
+	backupv1beta1 "github.com/open-cluster-management/cluster-backup-operator/api/v1beta1"
 	valeroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	//+kubebuilder:scaffold:imports
 )

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/open-cluster-management-io/cluster-backup-operator/api/v1beta1"
+	"github.com/open-cluster-management/cluster-backup-operator/api/v1beta1"
 )
 
 // find takes a slice and looks for an element in it. If found it will

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-cluster-management-io/cluster-backup-operator
+module github.com/open-cluster-management/cluster-backup-operator
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -31,8 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	backupv1beta1 "github.com/open-cluster-management-io/cluster-backup-operator/api/v1beta1"
-	"github.com/open-cluster-management-io/cluster-backup-operator/controllers"
+	backupv1beta1 "github.com/open-cluster-management/cluster-backup-operator/api/v1beta1"
+	"github.com/open-cluster-management/cluster-backup-operator/controllers"
 
 	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
 	chnv1 "github.com/open-cluster-management/multicloud-operators-channel/pkg/apis/apps/v1"


### PR DESCRIPTION
Hi all, I'm proposing to fix which basically it's a `sed s/open-cluster-management-io/open-cluster-management/g`. I'm not 100% positive about this but the rule (if any) it's not crystal clear (to me).
May you have a look and (if rejected) explain the rationale? Thanks 