### PR TITLE
update readme with execution details

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,12 @@ This project is licensed under the *Apache License 2.0*. A copy of the license c
 
 ## Getting Started
 The Cluster Back up and Restore Operator runs on the hub and depends on the [OADP Operator](https://github.com/openshift/oadp-operator) to install [Velero](https://velero.io/) on the ACM hub, which is then used to backup and restore ACM hub resources. 
-Before you can use the cluster operator, you need to install the OADP Operator first as described [here](https://github.com/openshift/oadp-operator#installing-operator).
+
+Before you can use the cluster operator, you first need to install the OADP Operator as described [here](https://github.com/openshift/oadp-operator#installing-operator).
 Make sure you follow the steps to create the [secret for the cloud storage](https://github.com/openshift/oadp-operator#creating-credentials-secret) where the backups are going to be saved, then use that secret when creating the [Velero resource](https://github.com/openshift/oadp-operator#creating-velero-cr).
+
+The Cluster Back up and Restore Operator resources must be created in the same namespace where the OADP Operator is installed. 
+
 
 ## Design
 The operator defines the `Backup.cluster.open-cluster-management.io` and `Restore.cluster.open-cluster-management.io` resources, used to setup a hub backup and restore configuration.
@@ -98,6 +102,8 @@ Before using Cluster Back up and Restore Operator backup or restore support you 
 
 Make sure you follow the OADP Operator installation instructions and create a Velero resource and a valid connection to a backup storage location where backups will be stored. Check the install and setup steps [here](https://github.com/openshift/oadp-operator#installing-operator).
 
+The Cluster Back up and Restore Operator resources must be created in the same namespace where the OADP Operator is installed. 
+
 If you are trying to use the Cluster Back up and Restore Operator to backup data, you have to create a `backup.cluster.open-cluster-management.io` resource which will be consumed by the operator and create all the necessary intermediary backup resources.
 
 If you are trying to use the Cluster Back up and Restore Operator to restore a backup, then you have to create a `restore.cluster.open-cluster-management.io` resource which will run the restore and execute any other post restore operations, such as registering restored remote clusters with the new hub.
@@ -152,7 +158,7 @@ kubectl create -n <ns> -f config/samples/cluster_v1beta1_backup.yaml
 
 ## Backup resources
 
-After you create a `backup.cluster.open-cluster-management.io` resource you should be able to run `oc get cbkp -A` and get the status of the backup executions.
+After you create a `backup.cluster.open-cluster-management.io` resource you should be able to run `oc get cbkp -n <oadp-operator-ns>` and get the status of the backup executions.
 
 In the example below, the last completed backup is `backup-acm-2021-08-10-140404` and a new backup is currently running `backup-acm-2021-08-10-151345`.
 The name of the backup follows this template: `acm-backup-<timestamp>`
@@ -160,17 +166,17 @@ The name of the backup follows this template: `acm-backup-<timestamp>`
 Example of a `backup.cluster.open-cluster-management.io` execution with a `velero.io.backup` in progress:
 
 ```
-$ oc get cbkp -n oadp_operator
+$ oc get cbkp -n oadp-operator
 NAMESPACE       NAME         PHASE        BACKUP                         LASTBACKUP                     LASTBACKUPTIME         DURATION   MESSAGE
 oadp-operator   backup-acm   InProgress   backup-acm-2021-08-10-151345   backup-acm-2021-08-10-140404   2021-08-10T18:22:07Z   18m3s      Velero Backup [backup-acm-2021-08-10-151345] phase:InProgress ItemsBackedUp[439], TotalItems[1410]
 ```
 
-Running the command below returns all `velero.io.backup` resources, created in the same namespace with the OADP Operator. Replace the `<oadp_operator_ns>` with the namespace name used to install the OADP Operator (the default value for the OADP Operator install namespace is `oadp_operator`).
+Running the command below returns all `velero.io.backup` resources, created in the same namespace with the OADP Operator. Replace the `<oadp-operator-ns>` with the namespace name used to install the OADP Operator (the default value for the OADP Operator install namespace is `oadp-operator`).
 
 You should also be able to see the backup files under the storage location defined when installing the OADP Operator.
 
 ```
-$ oc get backup -n <oadp_operator_ns>
+$ oc get backup -n <oadp-operator-ns>
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -160,16 +160,17 @@ The name of the backup follows this template: `acm-backup-<timestamp>`
 Example of a `backup.cluster.open-cluster-management.io` execution with a `velero.io.backup` in progress:
 
 ```
-$ oc get cbkp -A
+$ oc get cbkp -n oadp_operator
 NAMESPACE       NAME         PHASE        BACKUP                         LASTBACKUP                     LASTBACKUPTIME         DURATION   MESSAGE
 oadp-operator   backup-acm   InProgress   backup-acm-2021-08-10-151345   backup-acm-2021-08-10-140404   2021-08-10T18:22:07Z   18m3s      Velero Backup [backup-acm-2021-08-10-151345] phase:InProgress ItemsBackedUp[439], TotalItems[1410]
 ```
 
-Running the command below returns all `velero.io.backup` resources.
+Running the command below returns all `velero.io.backup` resources, created in the same namespace with the OADP Operator. Replace the `<oadp_operator_ns>` with the namespace name used to install the OADP Operator (the default value for the OADP Operator install namespace is `oadp_operator`).
+
 You should also be able to see the backup files under the storage location defined when installing the OADP Operator.
 
 ```
-$ oc get backup -A
+$ oc get backup -n <oadp_operator_ns>
 ```
 
 


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

- Updated Readme to explain the output of a Backup and Restore operation
- Added more info and links for the Velero and OADP op
- document that op resources must be in the same ns with the OADP operator
- updated oc get commands to replace -A with oadp ns

https://github.com/open-cluster-management/backlog/issues/15698