### PR TITLE
create watch rules for channel and managedcluster crd

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - apps.open-cluster-management.io
+  resources:
+  - channels
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - cluster.open-cluster-management.io
   resources:
   - backups
@@ -100,6 +108,23 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - velero.io
+  resources:
+  - backups
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - velero.io
+  resources:
+  - deletebackuprequests
+  verbs:
+  - create
 - apiGroups:
   - velero.io
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -69,14 +69,6 @@ rules:
 - apiGroups:
   - cluster.open-cluster-management.io
   resources:
-  - channels
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
   - managedclusters
   verbs:
   - get

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -212,11 +212,11 @@ func (r *BackupReconciler) createBackupForResource(
 
 	err := r.Get(ctx, veleroResIdentity, veleroResBackup)
 	if err != nil {
-		backupLogger.Info(
+		backupLogger.Info(fmt.Sprintf(
 			"velero.io.Backup [name=%s, namespace=%s] returned error, checking if the resource was not yet created",
 			veleroResIdentity.Name,
 			veleroResIdentity.Namespace,
-		)
+		))
 		// check if this is a  resource NotFound error, in which case create the resource
 		if k8serr.IsNotFound(err) {
 			// create backup based on resource type

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -48,6 +48,10 @@ type BackupReconciler struct {
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=backups,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=backups/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=backups/finalizers,verbs=update
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
+//+kubebuilder:rbac:groups=apps.open-cluster-management.io,resources=channels,verbs=get;list;watch
+//+kubebuilder:rbac:groups=velero.io,resources=backups,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups=velero.io,resources=deletebackuprequests,verbs=create
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -68,9 +72,9 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 
 		backupLogger.Info(
-			"Backup CR was not created in the %s namespace",
-			req.NamespacedName.Namespace,
-		)
+			fmt.Sprintf("Backup CR was not created in the %s namespace",
+				req.NamespacedName.Namespace,
+			))
 		return ctrl.Result{RequeueAfter: requeueInterval}, client.IgnoreNotFound(err)
 	}
 
@@ -148,11 +152,11 @@ func (r *BackupReconciler) submitAcmBackupSettings(
 	// get the velero CR using the veleroIdentity
 	err := r.Get(ctx, veleroIdentity, veleroBackup)
 	if err != nil {
-		backupLogger.Info(
+		backupLogger.Info(fmt.Sprintf(
 			"velero.io.Backup resource [name=%s, namespace=%s] returned error, checking if the resource was not yet created",
 			veleroIdentity.Name,
 			veleroIdentity.Namespace,
-		)
+		))
 
 		// check if this is a  resource NotFound error, in which case create the resource
 		if k8serr.IsNotFound(err) {


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

Fix https://github.com/open-cluster-management/backlog/issues/15746

Picked up the latest crd updates for schedule resource and included the fix from PR https://github.com/open-cluster-management/cluster-backup-operator/pull/24
I found it easier to create a new PR and add #24 on top of the latest then to push all schedule changes in that PR

With these changes, the controller starts successfully
The velero.io CRDs have been created prior to this step ( OADP Operator was installed )

```
vbirsan@redhat:cluster-backup-operator-2 vbirsan$ oc logs cluster-backup-operator-controller-manager-5d5fc5d9dc-gzj5f -n cluster-backup-operator-system -c manager
I0901 17:47:53.567238       1 request.go:655] Throttling request took 1.048109819s, request: GET:https://172.30.0.1:443/apis/node.k8s.io/v1?timeout=32s
2021-09-01T17:47:57.214Z	INFO	controller-runtime.metrics	metrics server is starting to listen	{"addr": "127.0.0.1:8080"}
2021-09-01T17:47:57.215Z	INFO	setup	starting manager
I0901 17:47:57.215836       1 leaderelection.go:243] attempting to acquire leader lease cluster-backup-operator-system/58497677.cluster.management.io...
2021-09-01T17:47:57.215Z	INFO	controller-runtime.manager	starting metrics server	{"path": "/metrics"}
I0901 17:47:57.329342       1 leaderelection.go:253] successfully acquired lease cluster-backup-operator-system/58497677.cluster.management.io
2021-09-01T17:47:57.329Z	DEBUG	controller-runtime.manager.events	Normal	{"object": {"kind":"ConfigMap","namespace":"cluster-backup-operator-system","name":"58497677.cluster.management.io","uid":"0fcd4c5f-f881-42ed-9c3b-39d016adfa3f","apiVersion":"v1","resourceVersion":"231445"}, "reason": "LeaderElection", "message": "cluster-backup-operator-controller-manager-5d5fc5d9dc-gzj5f_0fe99245-ab6a-4252-984e-24aaeb12d9fc became leader"}
2021-09-01T17:47:57.329Z	DEBUG	controller-runtime.manager.events	Normal	{"object": {"kind":"Lease","namespace":"cluster-backup-operator-system","name":"58497677.cluster.management.io","uid":"b26a191e-af36-4afe-a26e-29d18f8779a6","apiVersion":"coordination.k8s.io/v1","resourceVersion":"231446"}, "reason": "LeaderElection", "message": "cluster-backup-operator-controller-manager-5d5fc5d9dc-gzj5f_0fe99245-ab6a-4252-984e-24aaeb12d9fc became leader"}
2021-09-01T17:47:57.416Z	INFO	controller-runtime.manager.controller.restore	Starting EventSource	{"reconciler group": "cluster.open-cluster-management.io", "reconciler kind": "Restore", "source": "kind source: /, Kind="}
2021-09-01T17:47:57.416Z	INFO	controller-runtime.manager.controller.backup	Starting EventSource	{"reconciler group": "cluster.open-cluster-management.io", "reconciler kind": "Backup", "source": "kind source: /, Kind="}
2021-09-01T17:47:57.416Z	INFO	controller-runtime.manager.controller.backupschedule	Starting EventSource	{"reconciler group": "cluster.open-cluster-management.io", "reconciler kind": "BackupSchedule", "source": "kind source: /, Kind="}
2021-09-01T17:47:57.516Z	INFO	controller-runtime.manager.controller.backupschedule	Starting EventSource	{"reconciler group": "cluster.open-cluster-management.io", "reconciler kind": "BackupSchedule", "source": "kind source: /, Kind="}
2021-09-01T17:47:57.516Z	INFO	controller-runtime.manager.controller.backupschedule	Starting Controller	{"reconciler group": "cluster.open-cluster-management.io", "reconciler kind": "BackupSchedule"}
2021-09-01T17:47:57.517Z	INFO	controller-runtime.manager.controller.backupschedule	Starting workers	{"reconciler group": "cluster.open-cluster-management.io", "reconciler kind": "BackupSchedule", "worker count": 1}
2021-09-01T17:47:57.613Z	INFO	controller-runtime.manager.controller.backup	Starting Controller	{"reconciler group": "cluster.open-cluster-management.io", "reconciler kind": "Backup"}
2021-09-01T17:47:57.613Z	INFO	controller-runtime.manager.controller.restore	Starting Controller	{"reconciler group": "cluster.open-cluster-management.io", "reconciler kind": "Restore"}
2021-09-01T17:47:57.614Z	INFO	controller-runtime.manager.controller.restore	Starting workers	{"reconciler group": "cluster.open-cluster-management.io", "reconciler kind": "Restore", "worker count": 1}
2021-09-01T17:47:57.614Z	INFO	controller-runtime.manager.controller.backup	Starting workers	{"reconciler group": "cluster.open-cluster-management.io", "reconciler kind": "Backup", "worker count": 1}
```

If I create a cluster Backup resource without setting up the velero storage info, I see this
```
oc get cbkp -A
NAMESPACE       NAME         PHASE   BACKUP                         LASTBACKUP   LASTBACKUPTIME   DURATION   MESSAGE
oadp-operator   backup-acm           backup-acm-2021-09-01-160159                                            Velero Backup [backup-acm-2021-09-01-160159] Empty. If the status is empty check the velero pod is running and that you have created a Velero resource as documented in the install guide.
```

If velero.io Backup  CRD is not installed before we install the cluster backup operator :

``` oc logs cluster-backup-operator-controller-manager-7655f6848f-qx6q7 -n cluster-backup-operator-system -c manager
I0901 15:46:06.986404       1 request.go:655] Throttling request took 1.006506104s, request: GET:https://172.30.0.1:443/apis/operators.coreos.com/v1?timeout=32s
2021-09-01T15:46:10.381Z	INFO	controller-runtime.metrics	metrics server is starting to listen	{"addr": "127.0.0.1:8080"}
2021-09-01T15:46:16.389Z	ERROR	setup	unable to create controller	{"controller": "Backup", "error": "no matches for kind \"Backup\" in version \"velero.io/v1\""}
github.com/go-logr/zapr.(*zapLogger).Error
	/workspace/vendor/github.com/go-logr/zapr/zapr.go:132
sigs.k8s.io/controller-runtime/pkg/log.(*DelegatingLogger).Error
	/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/log/deleg.go:144
main.main
	/workspace/main.go:96
runtime.main
	/usr/local/go/src/runtime/proc.go:225
```