### PR TITLE
make backups TTL optional

### DIFF
--- a/api/v1beta1/schedule_types.go
+++ b/api/v1beta1/schedule_types.go
@@ -32,7 +32,7 @@ type BackupScheduleSpec struct {
 	VeleroSchedule string `json:"veleroSchedule"`
 	// TTL is a time.Duration-parseable string describing how long
 	// the Velero Backup should be retained for.
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	VeleroTTL metav1.Duration `json:"veleroTtl,omitempty"`
 }
 

--- a/config/crd/bases/cluster.open-cluster-management.io_backupschedules.yaml
+++ b/config/crd/bases/cluster.open-cluster-management.io_backupschedules.yaml
@@ -52,7 +52,6 @@ spec:
                 type: string
             required:
             - veleroSchedule
-            - veleroTtl
             type: object
           status:
             description: BackupScheduleStatus defines the observed state of BackupSchedule

--- a/config/samples/cluster_v1beta1_backupschedule.yaml
+++ b/config/samples/cluster_v1beta1_backupschedule.yaml
@@ -1,7 +1,7 @@
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: BackupSchedule
 metadata:
-  name: backup-schedule-acm
+  name: schedule-acm
 spec:
-  veleroSchedule: 0 */6 * * * #Create a backup every 6 hours
-  veleroTtl: 72h #delete after 72h
+  veleroSchedule: 0 */6 * * * # Create a backup every 6 hours
+  veleroTtl: 72h # deletes scheduled backups after 72h; optional, backups never expire if option not set

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -118,6 +118,22 @@ var _ = Describe("BackupSchedule controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, &rhacmBackupSchedule)).Should(Succeed())
+
+			rhacmBackupScheduleNoTTL := v1beta1.BackupSchedule{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "cluster.open-cluster-management.io/v1beta1",
+					Kind:       "BackupSchedule",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      backupScheduleName + "-nottl",
+					Namespace: veleroNamespaceName,
+				},
+				Spec: v1beta1.BackupScheduleSpec{
+					VeleroSchedule: "0 */6 * * *",
+				},
+			}
+			Expect(k8sClient.Create(ctx, &rhacmBackupScheduleNoTTL)).Should(Succeed())
+
 			backupLookupKey := types.NamespacedName{
 				Name:      backupScheduleName,
 				Namespace: veleroNamespaceName,


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

- On Schedule resource, make veleroTTL optional ( backups never expire if option not set )
- On the backupSchedule sample yaml, replace schedule name, frpm `backup-schedule-acm` to `schedule-acm` ( name is a bit too long after adding backup type prefix )
Schedule names are now
<img width="1110" alt="Screen Shot 2021-09-02 at 4 40 57 PM" src="https://user-images.githubusercontent.com/43010150/131913105-7ed6cb4d-9e9f-4906-98d6-a4556bfd42c1.png">

