### PR TITLE
add maxBackups to backupschedule operator

### DIFF
--- a/api/v1beta1/schedule_types.go
+++ b/api/v1beta1/schedule_types.go
@@ -34,6 +34,9 @@ type BackupScheduleSpec struct {
 	// the Velero Backup should be retained for.
 	// +kubebuilder:validation:Optional
 	VeleroTTL metav1.Duration `json:"veleroTtl,omitempty"`
+	// Maximum number of scheduled backups after which the old backups are being removed
+	// +kubebuilder:validation:Required
+	MaxBackups int `json:"maxBackups"`
 }
 
 // BackupScheduleStatus defines the observed state of BackupSchedule

--- a/config/crd/bases/cluster.open-cluster-management.io_backupschedules.yaml
+++ b/config/crd/bases/cluster.open-cluster-management.io_backupschedules.yaml
@@ -42,6 +42,10 @@ spec:
           spec:
             description: BackupScheduleSpec defines the desired state of BackupSchedule
             properties:
+              maxBackups:
+                description: Maximum number of scheduled backups after which the old
+                  backups are being removed
+                type: integer
               veleroSchedule:
                 description: Schedule is a Cron expression defining when to run the
                   Velero Backup
@@ -51,6 +55,7 @@ spec:
                   long the Velero Backup should be retained for.
                 type: string
             required:
+            - maxBackups
             - veleroSchedule
             type: object
           status:

--- a/config/samples/cluster_v1beta1_backupschedule.yaml
+++ b/config/samples/cluster_v1beta1_backupschedule.yaml
@@ -3,5 +3,6 @@ kind: BackupSchedule
 metadata:
   name: schedule-acm
 spec:
+  maxBackups: 10 # maximum number of backups after which old backups should be removed
   veleroSchedule: 0 */6 * * * # Create a backup every 6 hours
   veleroTtl: 72h # deletes scheduled backups after 72h; optional, backups never expire if option not set

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -148,7 +148,7 @@ func (r *BackupReconciler) submitAcmBackupSettings(
 
 	veleroIdentity := types.NamespacedName{
 		Namespace: backup.Namespace,
-		Name:      r.getActiveBackupName(ctx, backup, c),
+		Name:      getActiveBackupName(ctx, backup, c),
 	}
 
 	veleroBackup := &veleroapi.Backup{}
@@ -179,7 +179,7 @@ func (r *BackupReconciler) submitAcmBackupSettings(
 			backupLogger.Info(msg)
 
 			// clean up old backups if they exceed the maxCount number
-			r.cleanupBackups(ctx, backup, c)
+			cleanupBackups(ctx, backup.Spec.MaxBackups*3, c)
 
 			// set ACM backup configuration for managed clusters
 			setManagedClustersBackupInfo(ctx, &veleroBackup.Spec, c)
@@ -237,9 +237,9 @@ func (r *BackupReconciler) submitAcmBackupSettings(
 	}
 
 	// create credentials backup
-	r.createBackupForResource("creds", backup, veleroBackup, ctx, c)
+	createBackupForResource("creds", backup, veleroBackup, ctx, c)
 	// create resources backup
-	r.createBackupForResource("resource", backup, veleroBackup, ctx, c)
+	createBackupForResource("resource", backup, veleroBackup, ctx, c)
 
 	updateLastBackupStatus(backup)
 

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -113,6 +113,7 @@ var _ = Describe("BackupSchedule controller", func() {
 					Namespace: veleroNamespaceName,
 				},
 				Spec: v1beta1.BackupScheduleSpec{
+					MaxBackups:     2,
 					VeleroSchedule: "0 */6 * * *",
 					VeleroTTL:      metav1.Duration{Duration: time.Hour * 72},
 				},
@@ -130,6 +131,7 @@ var _ = Describe("BackupSchedule controller", func() {
 				},
 				Spec: v1beta1.BackupScheduleSpec{
 					VeleroSchedule: "0 */6 * * *",
+					MaxBackups:     2,
 				},
 			}
 			Expect(k8sClient.Create(ctx, &rhacmBackupScheduleNoTTL)).Should(Succeed())


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

Changes:
- add required property maxBackups to backupschedule resource
```
apiVersion: cluster.open-cluster-management.io/v1beta1
kind: BackupSchedule
metadata:
  name: schedule-acm
spec:
  maxBackups: 10 # maximum number of backups after which old backups should be removed
  veleroSchedule: 0 */6 * * * # Create a backup every 6 hours
  veleroTtl: 72h # deletes scheduled backups after 72h; optional, backups never expire if option not set
```

- updated readme to add the backupschedule resource and remove references to the backup ( we will keep only the backupschedule )