### PR TITLE
add debug details when schedule has no status

### DIFF
--- a/controllers/schedule.go
+++ b/controllers/schedule.go
@@ -34,7 +34,7 @@ const (
 	// EnabledPhaseMsg for when Velero schedules are processed by velero and enabled
 	EnabledPhaseMsg string = "Velero schedules are enabled"
 	// UnknownPhaseMsg for when some Velero schedules are not enabled
-	UnknownPhaseMsg string = "Some Velero schedules are not enabled"
+	UnknownPhaseMsg string = "Some Velero schedules are not enabled. If the status doesn't change check the velero pod is running and that you have created a Velero resource as documented in the install guide."
 )
 
 func updateScheduleStatus(


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

If the velero pod is in error or the Velero resource was not created, schedules have no status

Add extra details for troubleshooting