### PR TITLE
fix sonar vulnerabilities

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -62,8 +62,8 @@ func NewManagedClusterHandler(ctx context.Context,
 		errors                                        = []error{}
 		err                      error
 	)
-	for _, s := range adminKubeconfigSecrets {
-		if managedClusterKubeClient, err = getKubeClientFromSecret(&s); err == nil {
+	for i := range adminKubeconfigSecrets {
+		if managedClusterKubeClient, err = getKubeClientFromSecret(&adminKubeconfigSecrets[i]); err == nil {
 			break // for the moment we get the first one
 		}
 		errors = append(errors, fmt.Errorf("unable to get kubernetes client: %v", err))

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -55,8 +55,8 @@ var (
 )
 
 const (
-	managedClusterImportInterval            = 20 * time.Second // as soon restore is finished we start to poll for managedcluster registration
-	BootstrapHubKubeconfigSecretName        = "bootstrap-hub-kubeconfig"
+	managedClusterImportInterval            = 20 * time.Second                // as soon restore is finished we start to poll for managedcluster registration
+	BootstrapHubKubeconfigSecretName        = "bootstrap-hub-kubeconfig"      /* #nosec G101 */
 	OpenClusterManagementAgentNamespaceName = "open-cluster-management-agent" // TODO: this can change. Get the klusterlet.spec
 	OCMManagedClusterNamespaceLabelKey      = "cluster.open-cluster-management.io/managedCluster"
 )


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/open-cluster-management/backlog/issues/15943

- Fix gosec:G601 vulnerability based on 
https://stackoverflow.com/questions/62446118/implicit-memory-aliasing-in-for-loop

- Fix gosec:G101 

```
When a specific false positive has been identified and verified as safe, you may wish to suppress only that single rule (or a specific set of rules) within a section of code, while continuing to scan for other problems. To do this, you can list the rule(s) to be suppressed within the #nosec annotation, e.g: /* #nosec G401 */ or // #nosec G201 G202 G203
```