### PR TITLE
fix typo on argocd res names

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -41,7 +41,7 @@ var (
 		"ClusterPool", "ClusterDeployment", "MachinePool", "ClusterProvision",
 		"ClusterState", "ClusterSyncLease", "ClusterSync", "ClusterCurator"}
 	backupResources = [...]string{
-		"applications.argoprj.io", "applicationset.argoprj.io",
+		"applications.argoproj.io", "applicationset.argoproj.io",
 		"appprojects.argoproj.io", "argocds.argoproj.io",
 		"applications.app.k8s.io",
 		"channel", "subscription",


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

fix argo cd group typo