### PR TITLE
check only existing backups created by the acm schedule

### DIFF
--- a/api/v1beta1/restore_types.go
+++ b/api/v1beta1/restore_types.go
@@ -44,7 +44,6 @@ type RestoreSpec struct {
 
 // RestoreStatus defines the observed state of Restore
 type RestoreStatus struct {
-	// TODO: replace with core/v1 TypedLocalObjectReference
 	// +kubebuilder:validation:Optional
 	VeleroManagedClustersRestoreName string `json:"veleroManagedClustersRestoreName,omitempty"`
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/cluster.open-cluster-management.io_restores.yaml
+++ b/config/crd/bases/cluster.open-cluster-management.io_restores.yaml
@@ -140,7 +140,6 @@ spec:
               veleroCredentialsRestoreName:
                 type: string
               veleroManagedClustersRestoreName:
-                description: 'TODO: replace with core/v1 TypedLocalObjectReference'
                 type: string
               veleroResourcesRestoreName:
                 type: string

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -88,9 +88,9 @@ func cleanupBackups(
 
 		// get acm backups only when counting existing backups
 		sliceBackups := filterBackups(veleroBackupList.Items[:], func(bkp veleroapi.Backup) bool {
-			return strings.Contains(veleroScheduleNames[Credentials], bkp.Name) ||
-				strings.Contains(veleroScheduleNames[ManagedClusters], bkp.Name) ||
-				strings.Contains(veleroScheduleNames[Resources], bkp.Name)
+			return strings.HasPrefix(bkp.Name, veleroScheduleNames[Credentials]) ||
+				strings.HasPrefix(bkp.Name, veleroScheduleNames[ManagedClusters]) ||
+				strings.HasPrefix(bkp.Name, veleroScheduleNames[Resources])
 		})
 
 		if maxBackups < len(sliceBackups) {

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
+	v1beta1 "github.com/open-cluster-management/cluster-backup-operator/api/v1beta1"
 	chnv1 "github.com/open-cluster-management/multicloud-operators-channel/pkg/apis/apps/v1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -53,6 +55,17 @@ var (
 	backupCredsResources = [...]string{"secret"}
 )
 
+var (
+	apiGVString = v1beta1.GroupVersion.String()
+	// create credentials schedule first since this is the fastest one, followed by resources
+	// mapping ResourceTypes to Velero schedule names
+	veleroScheduleNames = map[ResourceType]string{
+		Credentials:     "acm-credentials-schedule",
+		Resources:       "acm-resources-schedule",
+		ManagedClusters: "acm-managed-clusters-schedule",
+	}
+)
+
 // clean up old backups if they exceed the maxCount number
 func cleanupBackups(
 	ctx context.Context,
@@ -73,7 +86,13 @@ func cleanupBackups(
 		}
 	} else {
 
-		sliceBackups := veleroBackupList.Items[:]
+		// get acm backups only when counting existing backups
+		sliceBackups := filterBackups(veleroBackupList.Items[:], func(bkp veleroapi.Backup) bool {
+			return strings.Contains(veleroScheduleNames[Credentials], bkp.Name) ||
+				strings.Contains(veleroScheduleNames[ManagedClusters], bkp.Name) ||
+				strings.Contains(veleroScheduleNames[Resources], bkp.Name)
+		})
+
 		if maxBackups < len(sliceBackups) {
 			// need to delete backups
 			// sort backups by create time
@@ -88,15 +107,6 @@ func cleanupBackups(
 				}
 				return timeA < timeB
 			})
-
-			backupsInError := filterBackups(sliceBackups, func(bkp veleroapi.Backup) bool {
-				return bkp.Status.Errors > 0
-			})
-
-			// delete backup in error first
-			for i := 0; i < min(len(backupsInError), maxBackups); i++ {
-				deleteBackup(ctx, &backupsInError[i], c)
-			}
 
 			for i := 0; i < len(sliceBackups)-maxBackups; i++ {
 				// delete extra backups now

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -109,10 +109,6 @@ func cleanupBackups(
 			})
 
 			for i := 0; i < len(sliceBackups)-maxBackups; i++ {
-				// delete extra backups now
-				if sliceBackups[i].Status.Errors > 0 {
-					continue // ignore error status backups, they were processed in the step above
-				}
 				deleteBackup(ctx, &sliceBackups[i], c)
 			}
 		}

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -56,17 +56,6 @@ const (
 	scheduleOwnerKey            = ".metadata.controller"
 )
 
-var (
-	apiGVString = v1beta1.GroupVersion.String()
-	// create credentials schedule first since this is the fastest one, followed by resources
-	// mapping ResourceTypes to Velero schedule names
-	veleroScheduleNames = map[ResourceType]string{
-		Credentials:     "acm-credentials-schedule",
-		Resources:       "acm-resources-schedule",
-		ManagedClusters: "acm-managed-clusters-schedule",
-	}
-)
-
 // BackupScheduleReconciler reconciles a BackupSchedule object
 type BackupScheduleReconciler struct {
 	client.Client


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

related to https://github.com/open-cluster-management/backlog/issues/16310

Changes:
- when getting the list of old backups, filter in only the ones generated by the acm scheduler; backups with names 