### PR TITLE
check if restore resource is in the velero ns

### DIFF
--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -246,6 +246,28 @@ var _ = Describe("Basic Restore controller", func() {
 					Name: veleroNamespaceName,
 				},
 			}
+			backupStorageLocation = &veleroapi.BackupStorageLocation{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "velero/v1",
+					Kind:       "BackupStorageLocation",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default",
+					Namespace: veleroNamespaceName,
+				},
+				Spec: veleroapi.BackupStorageLocationSpec{
+					AccessMode: "ReadWrite",
+					StorageType: veleroapi.StorageType{
+						ObjectStorage: &veleroapi.ObjectStorageLocation{
+							Bucket: "velero-backup-acm-dr",
+							Prefix: "velero",
+						},
+					},
+					Provider: "aws",
+				},
+			}
+			backupStorageLocation.Status.Phase = veleroapi.BackupStorageLocationPhaseAvailable
+
 			rhacmRestore = v1beta1.Restore{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "cluster.open-cluster-management.io/v1beta1",
@@ -655,5 +677,4 @@ var _ = Describe("Basic Restore controller", func() {
 			}, timeout, interval).Should(BeTrue())
 		})
 	})
-
 })


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/open-cluster-management/backlog/issues/16526

Changes:
- verify if the velero storageLocation object is in the same ns with the backup or restore operator resources
- show an error if they are not in the same namespace ; in the log and the resource status
- updated restore tests 