### PR TITLE
backup apps helm releases

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -48,6 +48,7 @@ var (
 		"applications.app.k8s.io",
 		"channel", "subscription",
 		"deployable",
+		"helmrelease",
 		"placementrule", "placement", "placementdecisions",
 		"PlacementBinding.policy.open-cluster-management.io",
 		"policy",


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

Backup helmrelease objects, excluding namespaces : local-cluster and acm ns

https://github.com/open-cluster-management/backlog/issues/16817