### PR TITLE
refactor backup content

### DIFF
--- a/config/samples/cluster_v1beta1_restore_passive.yaml
+++ b/config/samples/cluster_v1beta1_restore_passive.yaml
@@ -1,0 +1,11 @@
+# apply this resource to restore hub resources in a passive configuration
+# restored managed clusters will show as detached on the current hub, where this resource is applied
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Restore
+metadata:
+  name: restore-acm-passive
+  namespace: openshift-adp
+spec:
+  veleroManagedClustersBackupName: skip
+  veleroCredentialsBackupName: latest
+  veleroResourcesBackupName: latest

--- a/config/samples/restore-acm-passive-activate.yaml
+++ b/config/samples/restore-acm-passive-activate.yaml
@@ -1,0 +1,13 @@
+# apply this resource to activate a passive configuration
+# this resource can be applied after the restore-acm-passive configuration was applied on this hub
+# after this resource is applied, all restored managed clusters 
+# will resume connection on the current hub; hive clusters will automatically switch to this cluster
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Restore
+metadata:
+  name: restore-acm-passive-activate
+  namespace: openshift-adp
+spec:
+  veleroManagedClustersBackupName: latest
+  veleroCredentialsBackupName: skip
+  veleroResourcesBackupName: skip

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -22,10 +22,8 @@ import (
 	"sort"
 	"strings"
 
-	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
 	v1beta1 "github.com/open-cluster-management/cluster-backup-operator/api/v1beta1"
 	chnv1 "github.com/open-cluster-management/multicloud-operators-channel/pkg/apis/apps/v1"
-	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,13 +33,23 @@ import (
 )
 
 var (
-	backupNamespacesACM           = [...]string{"hive", "openshift-operator-lifecycle-manager"}
-	backupManagedClusterResources = [...]string{"secret", "configmap",
-		"ManagedCluster.cluster.open-cluster-management.io", "ManagedClusterAddon", "ServiceAccount",
-		"ManagedClusterInfo", "ManagedClusterSet", "ManagedClusterSetBindings", "KlusterletAddonConfig",
-		"ManagedClusterView", "ManagedCluster.clusterview.open-cluster-management.io",
-		"ClusterPool", "ClusterDeployment", "MachinePool", "ClusterProvision",
-		"ClusterState", "ClusterSyncLease", "ClusterSync", "ClusterCurator"}
+	// resources used to activate the connection between hub and managed clusters - activation resources
+	backupManagedClusterResources = [...]string{
+		"ManagedCluster.cluster.open-cluster-management.io", //global
+		"KlusterletAddonConfig",
+		"ManagedClusterAddon",
+		"ManagedClusterInfo",
+		"ManagedClusterSet",
+		"ManagedClusterSetBindings",
+		"ClusterPool",
+		"ClusterCurator",
+		"ManagedCluster.clusterview.open-cluster-management.io",
+		"ManagedClusterView",
+		"MultiClusterObservability", // global resource, observability
+		"Observatorium",             // observability
+	}
+
+	// all backup resources, except secrets, configmaps and managed cluster activation resources
 	backupResources = [...]string{
 		"applications.argoproj.io", "applicationset.argoproj.io",
 		"appprojects.argoproj.io", "argocds.argoproj.io",
@@ -52,8 +60,20 @@ var (
 		"placementrule", "placement", "placementdecisions",
 		"PlacementBinding.policy.open-cluster-management.io",
 		"policy",
+		"ClusterDeployment",
+		"MachinePool",
+		"ClusterSyncLease",
+		"ClusterSync",
 	}
-	backupCredsResources = [...]string{"secret"}
+	backupCredsResources = [...]string{
+		"secret",
+		"configmap",
+	}
+
+	// credentials labels
+	backupCredsUserLabel    = "cluster.open-cluster-management.io/type"   // user defined
+	backupCredsHiveLabel    = "hive.openshift.io/secret-type"             // hive
+	backupCredsClusterLabel = "cluster.open-cluster-management.io/backup" // generic
 )
 
 var (
@@ -61,9 +81,11 @@ var (
 	// create credentials schedule first since this is the fastest one, followed by resources
 	// mapping ResourceTypes to Velero schedule names
 	veleroScheduleNames = map[ResourceType]string{
-		Credentials:     "acm-credentials-schedule",
-		Resources:       "acm-resources-schedule",
-		ManagedClusters: "acm-managed-clusters-schedule",
+		Credentials:        "acm-credentials-schedule",
+		CredentialsHive:    "acm-credentials-hive-schedule",
+		CredentialsCluster: "acm-credentials-cluster-schedule",
+		Resources:          "acm-resources-schedule",
+		ManagedClusters:    "acm-managed-clusters-schedule",
 	}
 )
 
@@ -84,6 +106,8 @@ func cleanupBackups(
 		// get acm backups only when counting existing backups
 		sliceBackups := filterBackups(veleroBackupList.Items[:], func(bkp veleroapi.Backup) bool {
 			return strings.HasPrefix(bkp.Name, veleroScheduleNames[Credentials]) ||
+				strings.HasPrefix(bkp.Name, veleroScheduleNames[CredentialsHive]) ||
+				strings.HasPrefix(bkp.Name, veleroScheduleNames[CredentialsCluster]) ||
 				strings.HasPrefix(bkp.Name, veleroScheduleNames[ManagedClusters]) ||
 				strings.HasPrefix(bkp.Name, veleroScheduleNames[Resources])
 		})
@@ -196,7 +220,18 @@ func setCredsBackupInfo(
 	ctx context.Context,
 	veleroBackupTemplate *veleroapi.BackupSpec,
 	c client.Client,
+	credentialType string,
 ) {
+
+	var labelKey string
+	switch credentialType {
+	case string(HiveSecret):
+		labelKey = backupCredsHiveLabel
+	case string(ClusterSecret):
+		labelKey = backupCredsClusterLabel
+	default:
+		labelKey = backupCredsUserLabel
+	}
 
 	var clusterResource bool = false
 	veleroBackupTemplate.IncludeClusterResources = &clusterResource
@@ -216,7 +251,7 @@ func setCredsBackupInfo(
 		veleroBackupTemplate.LabelSelector.MatchExpressions = requirements
 	}
 	req := &v1.LabelSelectorRequirement{}
-	req.Key = "cluster.open-cluster-management.io/type"
+	req.Key = labelKey
 	req.Operator = "Exists"
 	veleroBackupTemplate.LabelSelector.MatchExpressions = append(
 		veleroBackupTemplate.LabelSelector.MatchExpressions,
@@ -230,9 +265,7 @@ func setManagedClustersBackupInfo(
 	veleroBackupTemplate *veleroapi.BackupSpec,
 	c client.Client,
 ) {
-
-	backupLogger := log.FromContext(ctx)
-	var clusterResource bool = true // include cluster level managed cluster resources
+	var clusterResource bool = true // include cluster level resources
 	veleroBackupTemplate.IncludeClusterResources = &clusterResource
 
 	for i := range backupManagedClusterResources { // managed clusters required resources, from namespace or cluster level
@@ -240,42 +273,6 @@ func setManagedClustersBackupInfo(
 			veleroBackupTemplate.IncludedResources,
 			backupManagedClusterResources[i],
 		)
-	}
-
-	for i := range backupNamespacesACM { // acm ns
-		veleroBackupTemplate.IncludedNamespaces = appendUnique(
-			veleroBackupTemplate.IncludedNamespaces,
-			backupNamespacesACM[i],
-		)
-	}
-
-	// add cluster pool namespaces
-	clusterPools := hivev1.ClusterPoolList{}
-	if err := c.List(ctx, &clusterPools, &client.ListOptions{}); err != nil {
-		backupLogger.Error(err, "failed to get hivev1.ClusterPoolList")
-	} else {
-		for i := range clusterPools.Items {
-			veleroBackupTemplate.IncludedNamespaces = appendUnique(
-				veleroBackupTemplate.IncludedNamespaces,
-				clusterPools.Items[i].Namespace,
-			)
-		}
-	}
-
-	// get managed clusters namespaces
-	managedClusterList := clusterv1.ManagedClusterList{}
-	if err := c.List(ctx, &managedClusterList, &client.ListOptions{}); err != nil {
-		backupLogger.Error(err, "failed to get clusterv1.ManagedClusterList")
-	} else {
-		for i := range managedClusterList.Items {
-			if managedClusterList.Items[i].Name == "local-cluster" {
-				continue
-			}
-			veleroBackupTemplate.IncludedNamespaces = appendUnique(
-				veleroBackupTemplate.IncludedNamespaces,
-				managedClusterList.Items[i].Name,
-			)
-		}
 	}
 }
 

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -87,7 +87,7 @@ func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		veleroStorageLocations == nil || len(veleroStorageLocations.Items) == 0 {
 
 		msg := "velero.io.BackupStorageLocation resources not found. " +
-			"Verify you have created a konveyor.openshift.io.Velero resource."
+			"Verify you have created a konveyor.openshift.io.Velero or oadp.openshift.io.DataProtectionApplications resource."
 		restoreLogger.Info(msg)
 
 		restore.Status.Phase = v1beta1.RestorePhaseError
@@ -329,7 +329,7 @@ func (r *RestoreReconciler) initVeleroRestores(
 ) error {
 	restoreLogger := log.FromContext(ctx)
 
-	veleroRestoresToCreate := make(map[ResourceType]*veleroapi.Restore, 3)
+	veleroRestoresToCreate := make(map[ResourceType]*veleroapi.Restore, 5)
 
 	// loop through resourceTypes to create a Velero restore per type
 	for key := range veleroScheduleNames {
@@ -340,7 +340,7 @@ func (r *RestoreReconciler) initVeleroRestores(
 			if restore.Spec.VeleroManagedClustersBackupName != nil {
 				backupName = *restore.Spec.VeleroManagedClustersBackupName
 			}
-		case Credentials:
+		case Credentials, CredentialsHive, CredentialsCluster:
 			if restore.Spec.VeleroCredentialsBackupName != nil {
 				backupName = *restore.Spec.VeleroCredentialsBackupName
 			}
@@ -370,19 +370,25 @@ func (r *RestoreReconciler) initVeleroRestores(
 				"type", key,
 			)
 			restore.Status.Phase = v1beta1.RestorePhaseError
-			restore.Status.LastMessage = fmt.Sprintf("Backup %s Not found", backupName)
+			restore.Status.LastMessage = fmt.Sprintf("Backup %s Not found for resource type: %s", backupName, key)
 
-			return err
+			if key != CredentialsHive && key != CredentialsCluster {
+				// ignore missing hive or cluster key backup files
+				// for the case when the backups were created with an older controller version
+				return err
+			}
+		} else {
+
+			veleroRestore.Name = getValidKsRestoreName(restore.Name, veleroBackupName)
+
+			veleroRestore.Namespace = restore.Namespace
+			veleroRestore.Spec.BackupName = veleroBackupName
+
+			if err := ctrl.SetControllerReference(restore, veleroRestore, r.Scheme); err != nil {
+				return err
+			}
+			veleroRestoresToCreate[key] = veleroRestore
 		}
-		veleroRestore.Name = getValidKsRestoreName(restore.Name, veleroBackupName)
-
-		veleroRestore.Namespace = restore.Namespace
-		veleroRestore.Spec.BackupName = veleroBackupName
-
-		if err := ctrl.SetControllerReference(restore, veleroRestore, r.Scheme); err != nil {
-			return err
-		}
-		veleroRestoresToCreate[key] = veleroRestore
 	}
 
 	if len(veleroRestoresToCreate) == 0 {

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -41,12 +41,27 @@ type ResourceType string
 const (
 	// ManagedClusters resource type
 	ManagedClusters ResourceType = "managedClusters"
-	// Credentials resource type
+	// Credentials resource type for user created credentials
 	Credentials ResourceType = "credentials"
+	// Credentials resource type for hive secrets
+	CredentialsHive ResourceType = "credentialsHive"
+	// Credentials resource type for managed cluster secrets
+	CredentialsCluster ResourceType = "credentialsCluster"
 	// Resources related to applications and policies
 	Resources ResourceType = "resources"
 )
 
+// SecretType is the type of secret
+type SecretType string
+
+const (
+	// hive created secrets
+	HiveSecret SecretType = "hive"
+	// managed cluster secrets
+	ClusterSecret SecretType = "cluster"
+	// user defined secrets
+	UserSecret SecretType = "user"
+)
 const updateStatusFailedMsg = "Could not update status"
 
 const (
@@ -94,7 +109,7 @@ func (r *BackupScheduleReconciler) Reconcile(
 		veleroStorageLocations == nil || len(veleroStorageLocations.Items) == 0 {
 
 		msg := "velero.io.BackupStorageLocation resources not found. " +
-			"Verify you have created a konveyor.openshift.io.Velero resource."
+			"Verify you have created a konveyor.openshift.io.Velero or oadp.openshift.io.DataProtectionApplications resource."
 		scheduleLogger.Info(msg)
 
 		backupSchedule.Status.Phase = v1beta1.SchedulePhaseFailedValidation
@@ -214,7 +229,7 @@ func (r *BackupScheduleReconciler) Reconcile(
 	// delete velero schedules if their spec needs to be updated or any of them is missing
 	// New velero schedules will be created in the next reconcile triggerd by the deletion
 	if isScheduleSpecUpdated(&veleroScheduleList, backupSchedule) ||
-		len(veleroScheduleList.Items) < 3 {
+		len(veleroScheduleList.Items) < 5 {
 		if err := r.deleteVeleroSchedules(ctx, backupSchedule, &veleroScheduleList); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -270,7 +285,11 @@ func (r *BackupScheduleReconciler) initVeleroSchedules(
 		case ManagedClusters:
 			setManagedClustersBackupInfo(ctx, veleroBackupTemplate, r.Client)
 		case Credentials:
-			setCredsBackupInfo(ctx, veleroBackupTemplate, r.Client)
+			setCredsBackupInfo(ctx, veleroBackupTemplate, r.Client, string(UserSecret))
+		case CredentialsHive:
+			setCredsBackupInfo(ctx, veleroBackupTemplate, r.Client, string(HiveSecret))
+		case CredentialsCluster:
+			setCredsBackupInfo(ctx, veleroBackupTemplate, r.Client, string(ClusterSecret))
 		case Resources:
 			setResourcesBackupInfo(ctx, veleroBackupTemplate, r.Client)
 		}

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -484,12 +484,7 @@ var _ = Describe("BackupSchedule controller", func() {
 						createdBackupSchedule.Status.VeleroScheduleResources.Spec.Template.ExcludedNamespaces,
 						chartsv1NSName,
 					)
-					// verify the cluster pool ns is included
-					_, clusterPoolsNSOK := find(
-						createdBackupSchedule.Status.VeleroScheduleManagedClusters.Spec.Template.IncludedNamespaces,
-						clusterPoolNSName,
-					)
-					return chartsNSOK && clusterPoolsNSOK
+					return chartsNSOK
 				}
 
 				return schedulesCreated
@@ -534,7 +529,7 @@ var _ = Describe("BackupSchedule controller", func() {
 				err := k8sClient.List(ctx, &veleroSchedulesList, &client.ListOptions{})
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
-			Expect(len(veleroSchedulesList.Items)).To(BeNumerically("==", 3))
+			Expect(len(veleroSchedulesList.Items)).To(BeNumerically("==", 5))
 			//
 
 			// new backup with no TTL
@@ -757,7 +752,7 @@ var _ = Describe("BackupSchedule controller", func() {
 				err := k8sClient.List(ctx, &veleroScheduleList, &client.ListOptions{})
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
-			Expect(len(veleroScheduleList.Items)).To(BeNumerically("==", 3))
+			Expect(len(veleroScheduleList.Items)).To(BeNumerically("==", 5))
 
 			// delete existing velero schedule
 			Eventually(func() bool {
@@ -766,7 +761,7 @@ var _ = Describe("BackupSchedule controller", func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			// count velero schedules, should still be 3
+			// count velero schedules, should still be 5
 			veleroScheduleList = veleroapi.ScheduleList{}
 			Eventually(func() int {
 				err := k8sClient.List(ctx, &veleroScheduleList, &client.ListOptions{})
@@ -774,7 +769,7 @@ var _ = Describe("BackupSchedule controller", func() {
 					return 0
 				}
 				return len(veleroScheduleList.Items)
-			}, timeout, interval).Should(BeNumerically("==", 3))
+			}, timeout, interval).Should(BeNumerically("==", 5))
 
 			// delete existing acm schedules
 			for i := range acmSchedulesList.Items {
@@ -926,7 +921,7 @@ var _ = Describe("BackupSchedule controller", func() {
 				Expect(
 					createdSchedule.Status.LastMessage,
 				).Should(BeIdenticalTo("velero.io.BackupStorageLocation resources not found. " +
-					"Verify you have created a konveyor.openshift.io.Velero resource."))
+					"Verify you have created a konveyor.openshift.io.Velero or oadp.openshift.io.DataProtectionApplications resource."))
 
 				// create the storage location now but in the wrong ns
 				Expect(k8sClient.Create(ctx, backupStorageLocation)).Should(Succeed())


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/open-cluster-management/backlog/issues/18199

Related to 
https://issues.redhat.com/projects/ACM/issues/ACM-1001

Changes: 
- updated managed cluster backup to include only resources used by backup; as tested , only this is needed to backup remote clusters : 
   	= to show the clusters as detached ( not try to connect to the new hub )
        "ClusterDeployment",
        "MachinePool",
        "ClusterSyncLease",
        "ClusterSync",
Secrets with this label: "hive.openshift.io/secret-type"


	= to activate the clusters ( activation data )

        "ManagedCluster.cluster.open-cluster-management.io", //global
        "KlusterletAddonConfig",
        "ManagedClusterAddon",
        "ManagedClusterInfo",
        "ManagedClusterSet",
        "ManagedClusterSetBindings",
        "ClusterPool",
        "ClusterCurator",
        "ManagedCluster.clusterview.open-cluster-management.io",
        "ManagedClusterView",


- with the above, I split the managed cluster backup in 2 : passive data and activation data
	= passive data , the 4 CRs , go under the resources backup; so when you restore the resources backup + secrets, you see all managed clusters in detached state. Original hub is still in charge, active; so we can move this data to multiple clusters and prepare them to take over during a disaster recovery. In this way the recovery time is very fast, we only need to restore the activation backup.
	= activation stays under the managed cluster backup; so when you restore this backup , the hub becomes the active one

- credentials backup have now 2 more backups : hive and cluster credentials
This is because we can’t include secrets in a backup and have an OR clause ( secrets have hive.openshift.io/secret-type OR cluster.open-cluster-management.io/type OR cluster.open-cluster-management.io/backup )

