### PR TITLE
remove from backup internal resources

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -33,10 +33,6 @@ import (
 )
 
 var (
-	// specifically exclude resources from these api groups
-	excludedAPIGroups = [...]string{
-		"work.open-cluster-management.io",
-	}
 	// resources used to activate the connection between hub and managed clusters - activation resources
 	backupManagedClusterResources = [...]string{
 		"ManagedCluster.cluster.open-cluster-management.io", //global

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -33,12 +33,15 @@ import (
 )
 
 var (
+	// specifically exclude resources from these api groups
+	excludedAPIGroups = [...]string{
+		"work.open-cluster-management.io",
+	}
 	// resources used to activate the connection between hub and managed clusters - activation resources
 	backupManagedClusterResources = [...]string{
 		"ManagedCluster.cluster.open-cluster-management.io", //global
 		"KlusterletAddonConfig",
 		"ManagedClusterAddon",
-		"ManagedClusterInfo",
 		"ManagedClusterSet",
 		"ManagedClusterSetBindings",
 		"ClusterPool",
@@ -62,8 +65,6 @@ var (
 		"policy",
 		"ClusterDeployment",
 		"MachinePool",
-		"ClusterSyncLease",
-		"ClusterSync",
 	}
 	backupCredsResources = [...]string{
 		"secret",


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

related to https://github.com/open-cluster-management/backlog/issues/18200

Removing resources not needing to be backed up ; they are recreated on the new hub by owning resources

"hiveinternal.openshift.io/v1alpha1": [
    "clustersync",
    "clustersynclease"
  ],

"internal.open-cluster-management.io/v1beta1": [
    "managedclusterinfo"
  ],
