### PR TITLE
create generic resources backup

### DIFF
--- a/config/samples/cluster_v1beta1_backupschedule.yaml
+++ b/config/samples/cluster_v1beta1_backupschedule.yaml
@@ -1,8 +1,15 @@
+#  veleroTtl - optional; deletes scheduled backups after specified time
+#  if veleroTtl is not specified, the maximum default value set by velero is used - 720h
+# 
+# veleroSchedule - cron job to start new acm backups
+#
+# maxBackups - maximum number of acm backups after which old acm backups should be removed
+#
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: BackupSchedule
 metadata:
   name: schedule-acm
 spec:
-  maxBackups: 10 # maximum number of backups after which old backups should be removed
-  veleroSchedule: 0 */6 * * * # Create a backup every 6 hours
-  veleroTtl: 72h # deletes scheduled backups after 72h; optional, if not specified, the maximum default value set by velero is used - 720h
+  maxBackups: 20
+  veleroSchedule: 0 */6 * * *
+  veleroTtl: 240h

--- a/config/samples/cluster_v1beta1_restore_passive.yaml
+++ b/config/samples/cluster_v1beta1_restore_passive.yaml
@@ -4,7 +4,6 @@ apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Restore
 metadata:
   name: restore-acm-passive
-  namespace: openshift-adp
 spec:
   veleroManagedClustersBackupName: skip
   veleroCredentialsBackupName: latest

--- a/config/samples/cluster_v1beta1_restore_passive_activate.yaml
+++ b/config/samples/cluster_v1beta1_restore_passive_activate.yaml
@@ -6,7 +6,6 @@ apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Restore
 metadata:
   name: restore-acm-passive-activate
-  namespace: openshift-adp
 spec:
   veleroManagedClustersBackupName: latest
   veleroCredentialsBackupName: skip

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,5 +1,0 @@
-## Append samples you want in your CSV to this file as resources ##
-resources:
-- cluster_v1beta1_restore.yaml
-- cluster_v1beta1_backupschedule.yaml
-#+kubebuilder:scaffold:manifestskustomizesamples

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -41,6 +41,7 @@ var (
 	includedAPIGroupsByName = []string{
 		"argoproj.io",
 		"app.k8s.io",
+		"core.observatorium.io",
 		//"hive.openshift.io",
 	}
 

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -254,7 +254,7 @@ func setGenericResourcesBackupInfo(
 	veleroBackupTemplate.IncludeClusterResources = &clusterResource
 
 	for i := range backupCredsResources { // exclude resources already backed up by creds
-		veleroBackupTemplate.IncludedResources = appendUnique(
+		veleroBackupTemplate.ExcludedResources = appendUnique(
 			veleroBackupTemplate.ExcludedResources,
 			backupCredsResources[i],
 		)

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -383,7 +383,7 @@ func getResourcesToBackup(
 	if err != nil {
 		return backupResourceNames, fmt.Errorf("failed to get server groups: %v", err)
 	}
-	if groupList != nil {
+	if groupList == nil {
 		return backupResourceNames, nil
 	}
 	for _, group := range groupList.Groups {

--- a/controllers/backup_test.go
+++ b/controllers/backup_test.go
@@ -98,6 +98,8 @@ var _ = Describe("Backup", func() {
 		})
 
 		It("filterBackups should work as expected", func() {
+			startTimestamp := &metav1.Time{}
+
 			sliceBackups := []veleroapi.Backup{
 				veleroapi.Backup{
 					TypeMeta: metav1.TypeMeta{
@@ -112,8 +114,9 @@ var _ = Describe("Backup", func() {
 						IncludedNamespaces: []string{"please-keep-this-one"},
 					},
 					Status: veleroapi.BackupStatus{
-						Phase:  veleroapi.BackupPhaseCompleted,
-						Errors: 0,
+						Phase:          veleroapi.BackupPhaseCompleted,
+						StartTimestamp: startTimestamp,
+						Errors:         0,
 					},
 				},
 				veleroapi.Backup{
@@ -129,8 +132,9 @@ var _ = Describe("Backup", func() {
 						IncludedNamespaces: []string{"please-keep-this-one"},
 					},
 					Status: veleroapi.BackupStatus{
-						Phase:  veleroapi.BackupPhaseCompleted,
-						Errors: 0,
+						Phase:          veleroapi.BackupPhaseCompleted,
+						StartTimestamp: startTimestamp,
+						Errors:         0,
 					},
 				},
 				veleroapi.Backup{
@@ -146,8 +150,9 @@ var _ = Describe("Backup", func() {
 						IncludedNamespaces: []string{"please-keep-this-one"},
 					},
 					Status: veleroapi.BackupStatus{
-						Phase:  veleroapi.BackupPhaseCompleted,
-						Errors: 0,
+						Phase:          veleroapi.BackupPhaseCompleted,
+						StartTimestamp: startTimestamp,
+						Errors:         0,
 					},
 				},
 				veleroapi.Backup{

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -337,7 +337,7 @@ func (r *RestoreReconciler) initVeleroRestores(
 ) error {
 	restoreLogger := log.FromContext(ctx)
 
-	veleroRestoresToCreate := make(map[ResourceType]*veleroapi.Restore, 6)
+	veleroRestoresToCreate := make(map[ResourceType]*veleroapi.Restore, len(veleroScheduleNames))
 
 	// loop through resourceTypes to create a Velero restore per type
 	for key := range veleroScheduleNames {

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -236,7 +236,7 @@ func (r *BackupScheduleReconciler) Reconcile(
 	// delete velero schedules if their spec needs to be updated or any of them is missing
 	// New velero schedules will be created in the next reconcile triggerd by the deletion
 	if isScheduleSpecUpdated(&veleroScheduleList, backupSchedule) ||
-		len(veleroScheduleList.Items) < 5 {
+		len(veleroScheduleList.Items) < len(veleroScheduleNames) {
 		if err := r.deleteVeleroSchedules(ctx, backupSchedule, &veleroScheduleList); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -50,6 +50,10 @@ const (
 	CredentialsCluster ResourceType = "credentialsCluster"
 	// Resources related to applications and policies
 	Resources ResourceType = "resources"
+	// Genric Resources related to applications and policies
+	// these are user resources, except secrets, labeled with cluster.open-cluster-management.io/backup
+	// secrets labeled with cluster.open-cluster-management.io/backup are already backed up under credentialsCluster
+	ResourcesGeneric ResourceType = "resourcesGeneric"
 )
 
 // SecretType is the type of secret
@@ -296,6 +300,9 @@ func (r *BackupScheduleReconciler) initVeleroSchedules(
 			setCredsBackupInfo(ctx, veleroBackupTemplate, r.Client, string(ClusterSecret))
 		case Resources:
 			setResourcesBackupInfo(ctx, veleroBackupTemplate, resourcesToBackup, r.Client)
+		case ResourcesGeneric:
+			setGenericResourcesBackupInfo(ctx, veleroBackupTemplate, r.Client)
+
 		}
 
 		veleroSchedule.Spec.Template = *veleroBackupTemplate

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -858,8 +858,9 @@ var _ = Describe("BackupSchedule controller", func() {
 						IncludedNamespaces: []string{"please-keep-this-one"},
 					},
 					Status: veleroapi.BackupStatus{
-						Phase:  veleroapi.BackupPhaseCompleted,
-						Errors: 0,
+						Phase:          veleroapi.BackupPhaseCompleted,
+						StartTimestamp: &metav1.Time{},
+						Errors:         0,
 					},
 				},
 			}

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -523,13 +523,13 @@ var _ = Describe("BackupSchedule controller", func() {
 				return createdBackupSchedule.Status.VeleroScheduleManagedClusters.Spec.Template.TTL
 			}, timeout, interval).Should(BeIdenticalTo(metav1.Duration{Duration: time.Hour * 150}))
 
-			// count velero schedules, should be still just 6
+			// count velero schedules, should be still len(veleroScheduleNames)
 			veleroSchedulesList := veleroapi.ScheduleList{}
 			Eventually(func() bool {
 				err := k8sClient.List(ctx, &veleroSchedulesList, &client.ListOptions{})
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
-			Expect(len(veleroSchedulesList.Items)).To(BeNumerically("==", 6))
+			Expect(len(veleroSchedulesList.Items)).To(BeNumerically("==", len(veleroScheduleNames)))
 			//
 
 			// new backup with no TTL
@@ -738,7 +738,10 @@ var _ = Describe("BackupSchedule controller", func() {
 				createdBackupScheduleValidCronExp.Spec.VeleroSchedule,
 			).Should(BeIdenticalTo(backupSchedule))
 
-			// count acm schedules
+			// count ACM ( NOT velero) schedules, should be still just 5
+			// this nb is NOT the nb of velero backup schedules created from
+			// the acm backupschdule object ( which is len(acmSchedulesList.Items))
+			// it represents the nb of ACM - BackupSchedule.cluster.open-cluster-management.io - schedules created by the tests
 			acmSchedulesList := v1beta1.BackupScheduleList{}
 			Eventually(func() bool {
 				err := k8sClient.List(ctx, &acmSchedulesList, &client.ListOptions{})
@@ -752,7 +755,7 @@ var _ = Describe("BackupSchedule controller", func() {
 				err := k8sClient.List(ctx, &veleroScheduleList, &client.ListOptions{})
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
-			Expect(len(veleroScheduleList.Items)).To(BeNumerically("==", 6))
+			Expect(len(veleroScheduleList.Items)).To(BeNumerically("==", len(veleroScheduleNames)))
 
 			// delete existing velero schedule
 			Eventually(func() bool {

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -523,13 +523,13 @@ var _ = Describe("BackupSchedule controller", func() {
 				return createdBackupSchedule.Status.VeleroScheduleManagedClusters.Spec.Template.TTL
 			}, timeout, interval).Should(BeIdenticalTo(metav1.Duration{Duration: time.Hour * 150}))
 
-			// count velero schedules, should be still just 3
+			// count velero schedules, should be still just 6
 			veleroSchedulesList := veleroapi.ScheduleList{}
 			Eventually(func() bool {
 				err := k8sClient.List(ctx, &veleroSchedulesList, &client.ListOptions{})
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
-			Expect(len(veleroSchedulesList.Items)).To(BeNumerically("==", 5))
+			Expect(len(veleroSchedulesList.Items)).To(BeNumerically("==", 6))
 			//
 
 			// new backup with no TTL
@@ -752,7 +752,7 @@ var _ = Describe("BackupSchedule controller", func() {
 				err := k8sClient.List(ctx, &veleroScheduleList, &client.ListOptions{})
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
-			Expect(len(veleroScheduleList.Items)).To(BeNumerically("==", 5))
+			Expect(len(veleroScheduleList.Items)).To(BeNumerically("==", 6))
 
 			// delete existing velero schedule
 			Eventually(func() bool {

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -738,10 +738,11 @@ var _ = Describe("BackupSchedule controller", func() {
 				createdBackupScheduleValidCronExp.Spec.VeleroSchedule,
 			).Should(BeIdenticalTo(backupSchedule))
 
-			// count ACM ( NOT velero) schedules, should be still just 5
+			// count ACM ( NOT velero) schedules, should still be just 5
 			// this nb is NOT the nb of velero backup schedules created from
-			// the acm backupschdule object ( which is len(acmSchedulesList.Items))
-			// it represents the nb of ACM - BackupSchedule.cluster.open-cluster-management.io - schedules created by the tests
+			// the acm backupschedule object ( these velero schedules are len(veleroScheduleNames))
+			// acmSchedulesList represents the ACM - BackupSchedule.cluster.open-cluster-management.io - schedules
+			// created by the tests
 			acmSchedulesList := v1beta1.BackupScheduleList{}
 			Eventually(func() bool {
 				err := k8sClient.List(ctx, &acmSchedulesList, &client.ListOptions{})

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -773,7 +773,7 @@ var _ = Describe("BackupSchedule controller", func() {
 					return 0
 				}
 				return len(veleroScheduleList.Items)
-			}, timeout, interval).Should(BeNumerically("==", 5))
+			}, timeout, interval).Should(BeNumerically("==", len(veleroScheduleNames)))
 
 			// delete existing acm schedules
 			for i := range acmSchedulesList.Items {

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -67,3 +67,10 @@ func getValidKsRestoreName(clusterRestoreName string, backupName string) string 
 	}
 	return fullName
 }
+
+// SortResourceType implements sort.Interface
+type SortResourceType []ResourceType
+
+func (a SortResourceType) Len() int           { return len(a) }
+func (a SortResourceType) Less(i, j int) bool { return a[i] < a[j] }
+func (a SortResourceType) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/18200

Changes:

- Create a new resources backup for resources with label `cluster.open-cluster-management.io/backup`
```
spec:
  defaultVolumesToRestic: false
  excludedResources:
    - secret
  hooks: {}
  includeClusterResources: true
  labelSelector:
    matchExpressions:
      - key: cluster.open-cluster-management.io/backup
        operator: Exists
```
- sort schedule names to create first the credentials schedules, then clusters, last resources

- updated the tests to use len(veleroScheduleNames) instead of 3-6


- updated this tests - acm backupschedules confused with velero schedules
```
			// count ACM ( NOT velero) schedules, should be still just 5
			// this nb is NOT the nb of velero backup schedules created from
			// the acm backupschdule object ( which is len(acmSchedulesList.Items))
			// it represents the nb of ACM - BackupSchedule.cluster.open-cluster-management.io - schedules created by the tests
			acmSchedulesList := v1beta1.BackupScheduleList{}
			Eventually(func() bool {
				err := k8sClient.List(ctx, &acmSchedulesList, &client.ListOptions{})
				return err == nil
			}, timeout, interval).Should(BeTrue())
			Expect(len(acmSchedulesList.Items)).To(BeNumerically("==", 5))
```

